### PR TITLE
output_utils: image location fix

### DIFF
--- a/plotextractor/output_utils.py
+++ b/plotextractor/output_utils.py
@@ -258,40 +258,17 @@ def get_image_location(image, sdir, image_list, recurred=False):
         image_list = os.listdir(sdir)
 
     for png_image in image_list:
-        img_dir, img_name = os.path.split(png_image)
-        if converted_image_should_be == img_name:
-            return os.path.join(img_dir, converted_image_should_be)
+        png_image_rel = os.path.relpath(png_image, start=sdir)
+        if converted_image_should_be == png_image_rel:
+            return png_image
 
-    # maybe it's in a subfolder called eps (TeX just understands that)
-    if os.path.isdir(os.path.join(sdir, 'eps')):
-        image_list = os.listdir(os.path.join(sdir, 'eps'))
-        for png_image in image_list:
-            if converted_image_should_be == png_image:
-                return os.path.join('eps', png_image)
-
-    if os.path.isdir(os.path.join(sdir, 'fig')):
-        image_list = os.listdir(os.path.join(sdir, 'fig'))
-        for png_image in image_list:
-            if converted_image_should_be == png_image:
-                return os.path.join('fig', png_image)
-
-    if os.path.isdir(os.path.join(sdir, 'figs')):
-        image_list = os.listdir(os.path.join(sdir, 'figs'))
-        for png_image in image_list:
-            if converted_image_should_be == png_image:
-                return os.path.join('figs', png_image)
-
-    if os.path.isdir(os.path.join(sdir, 'Figures')):
-        image_list = os.listdir(os.path.join(sdir, 'Figures'))
-        for png_image in image_list:
-            if converted_image_should_be == png_image:
-                return os.path.join('Figures', png_image)
-
-    if os.path.isdir(os.path.join(sdir, 'Figs')):
-        image_list = os.listdir(os.path.join(sdir, 'Figs'))
-        for png_image in image_list:
-            if converted_image_should_be == png_image:
-                return os.path.join('Figs', png_image)
+    # maybe it's in a subfolder (TeX just understands that)
+    for prefix in ['eps', 'fig', 'figs', 'Figures', 'Figs', 'images']:
+        if os.path.isdir(os.path.join(sdir, prefix)):
+            image_list = os.listdir(os.path.join(sdir, prefix))
+            for png_image in image_list:
+                if converted_image_should_be == png_image:
+                    return os.path.join(sdir, prefix, png_image)
 
     # maybe it is actually just loose.
     for png_image in os.listdir(sdir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -55,6 +55,14 @@ def tarball_nested_folder():
                         '1603.04438v1.tar.gz')
 
 
+@pytest.fixture
+def tarball_nested_folder_rotation():
+    """Return path to testdata with images in a nested folder."""
+    return os.path.join(os.path.dirname(__file__),
+                        'data',
+                        '1603.05617v1.tar.gz')
+
+
 def test_process_api(tarball_flat):
     """Test simple API for extracting and linking files to TeX."""
     plots = plotextractor.process_tarball(tarball_flat)
@@ -84,6 +92,17 @@ def test_process_api_with_nested(tarball_nested_folder):
     """Test simple API for extracting and linking files to TeX context."""
     plots = plotextractor.process_tarball(tarball_nested_folder, context=True)
     assert len(plots) == 9
+    assert "contexts" in plots[0]
+    assert "label" in plots[0]
+    assert "original_url" in plots[0]
+    assert "captions" in plots[0]
+    assert "name" in plots[0]
+
+
+def test_process_api_with_nested_rotation(tarball_nested_folder_rotation):
+    """Test simple API for extracting and linking files to TeX context."""
+    plots = plotextractor.process_tarball(tarball_nested_folder_rotation, context=True)
+    assert len(plots) == 30
     assert "contexts" in plots[0]
     assert "label" in plots[0]
     assert "original_url" in plots[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,11 +29,25 @@ import plotextractor
 
 
 def test_get_image_location_ok(tmpdir):
-    image = "img.png"
-    path = six.text_type(tmpdir.mkdir('images').join(image))
+    image = "img/img.png"
+    path = six.text_type(tmpdir.mkdir('img').join("img.png"))
     image_list = [path]
 
     assert path == plotextractor.output_utils.get_image_location(
+        image,
+        six.text_type(tmpdir),
+        image_list
+    )
+
+
+def test_get_image_location_missing_subfolder(tmpdir):
+    image = "img.png"
+    path = tmpdir.mkdir('fig').join(image)
+    path.write('test')
+    filepath = six.text_type(path)
+    image_list = [filepath]
+
+    assert filepath == plotextractor.output_utils.get_image_location(
         image,
         six.text_type(tmpdir),
         image_list
@@ -54,7 +68,7 @@ def test_get_image_location_not_ok(tmpdir):
 
 def test_get_image_location_includegraphics(tmpdir):
     image = "\\includegraphics{some}"
-    path = six.text_type(tmpdir.mkdir('images').join("some.png"))
+    path = six.text_type(tmpdir.join("some.png"))
     image_list = [path]
 
     assert path == plotextractor.output_utils.get_image_location(


### PR DESCRIPTION
* Supports the case of linking images to TeX reference when
  images are referred to without specifying full relative
  folder path.

* Adds more test cases for image location finder.

Signed-off-by: Jan Aage Lavik <jan.age.lavik@cern.ch>