### PR TITLE
untar set mtimes to now

### DIFF
--- a/plotextractor/converter.py
+++ b/plotextractor/converter.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of plotextractor.
-# Copyright (C) 2010, 2011, 2015 CERN.
+# Copyright (C) 2010, 2011, 2015, 2016 CERN.
 #
 # plotextractor is free software; you can redistribute it
 # and/or modify it under the terms of the GNU General Public License as
@@ -30,6 +30,8 @@ import os
 import tarfile
 import re
 
+from time import time
+
 from subprocess32 import check_output, TimeoutExpired
 
 from wand.exceptions import MissingDelegateError, ResourceLimitError
@@ -54,6 +56,10 @@ def untar(original_tarball, output_directory):
         raise InvalidTarball
 
     tarball = tarfile.open(original_tarball)
+    # set mtimes of members to now
+    epochsecs = int(time())
+    for member in tarball.getmembers():
+        member.mtime = epochsecs
     tarball.extractall(output_directory)
 
     file_list = []


### PR DESCRIPTION
as far as I can tell
`inspire-next/inspirehep/modules/workflows/tasks/arxiv.py`
uses
`from plotextractor.converter import untar`

and `untar` preserves the `mtimes` in the `tar` file. This leads to premature garbage collection on "old" files.

This patch changes the mtime of all members of the tar file to `int(time.time())` which is seconds since epoch for `now` 

Signed-off-by: Thorsten Schwander <thorsten.schwander@gmail.com>