### PR TITLE
Fix ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
-sudo: false
+sudo: true
 
 addons:
   apt:
@@ -39,6 +39,8 @@ install:
   - pip install coveralls check-manifest
   - pip install pytest pytest-pep8 pytest-cov pytest-cache
   - pip install -e .[docs,tests]
+  # see https://stackoverflow.com/questions/52703123/override-default-imagemagick-policy-xml
+  - sudo sed -i 's/domain="coder" rights="none"/domain="coder" rights="read\|write"/' /etc/ImageMagick-6/policy.xml
 
 script:
   - sphinx-build -qnNW docs docs/_build/html

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,10 @@
 Changes
 =======
 
+Version 0.2.2 (2019-10-24)
+
+- Try to preserve the ordering of figures.
+
 Version 0.2.1 (2018-09-07)
 
 - Handle utf-8 in paths inside the tarball.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ===================================
- plotextractor v0.2.1 is released
+ plotextractor v0.2.2 is released
 ===================================
 
-plotextractor v0.2.1 was released on 2018-09-07
+plotextractor v0.2.2 was released on 2019-10-24
 
 About
 -----
@@ -18,7 +18,7 @@ What's new
 Installation
 ------------
 
-   $ pip install plotextractor==0.2.1
+   $ pip install plotextractor==0.2.2
 
 Documentation
 -------------

--- a/plotextractor/output_utils.py
+++ b/plotextractor/output_utils.py
@@ -27,6 +27,8 @@ from __future__ import absolute_import, print_function
 import os
 import re
 
+from collections import OrderedDict
+
 
 def find_open_and_close_braces(line_index, start, brace, lines):
     """
@@ -182,7 +184,7 @@ def prepare_image_data(extracted_image_data, output_directory,
     :return extracted_image_data ([(string, string, list, list) ...],
         ...])) again the list of image data cleaned for output
     """
-    img_list = {}
+    img_list = OrderedDict()
     for image, caption, label in extracted_image_data:
         if not image or image == 'ERROR':
             continue

--- a/plotextractor/version.py
+++ b/plotextractor/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -85,6 +85,39 @@ def test_process_api(tarball_flat):
     assert plots[0]["name"]
 
 
+def test_process_api_preserves_ordering_of_figures_with_one_source_file(tarball_flat):
+    plots = plotextractor.process_tarball(tarball_flat)
+    expected = [
+        'd15-120f1',
+        'd15-120f2',
+        'd15-120f3a',
+        'd15-120f3b',
+        'd15-120f3c',
+        'd15-120f3d',
+        'd15-120f4',
+        'd15-120f5',
+        'd15-120f6a',
+        'd15-120f6b',
+        'd15-120f6c',
+        'd15-120f6d',
+        'd15-120f6e',
+        'd15-120f7',
+        'd15-120f8',
+        'd15-120f9',
+        'd15-120f10',
+        'd15-120f11',
+        'd15-120f12a',
+        'd15-120f12b',
+        'd15-120f12c',
+        'd15-120f13'
+    ]
+    labels = [plot['name'] for plot in plots]
+
+    assert len(plots) == 22
+    assert expected == labels
+
+
+
 def test_process_api_with_context(tarball_flat):
     """Test simple API for extracting and linking files to TeX context."""
     plots = plotextractor.process_tarball(tarball_flat, context=True)


### PR DESCRIPTION
* Figures are now listed in the order in which they appear in the
  document. This only works reliably in the (probably most common) case
  where there is only one LaTeX source file, as no attempt is done to
  understand the ordering in which subdocuments are included in the main
  document (with `\input`, `\include`, etc.). If there are multiple
  source files, the ordering of them is random, but figures will be
  ordered correctly within each source files, which is already an
  improvement over the current random order.

* INSPIR-2865
