### PR TITLE
Fix rotation

### DIFF
--- a/plotextractor/converter.py
+++ b/plotextractor/converter.py
@@ -225,6 +225,7 @@ def rotate_image(filename, line, sdir, image_list):
         if not os.path.exists(file_loc):
             return False
 
+        degrees = -degrees  # ImageMagick and graphicx use opposite conventions
         with Image(filename=file_loc) as image:
             with image.clone() as rotated:
                 rotated.rotate(degrees)

--- a/plotextractor/converter.py
+++ b/plotextractor/converter.py
@@ -205,7 +205,7 @@ def rotate_image(filename, line, sdir, image_list):
     :return: True if something was rotated
     """
     file_loc = get_image_location(filename, sdir, image_list)
-    degrees = re.findall('(angle=[-\\d]+|rotate=[-\\d]+)', line)
+    degrees = re.findall(r'(\bangle=-?[\d]+|\brotate=-?[\d]+)', line)
 
     if len(degrees) < 1:
         return False


### PR DESCRIPTION
Fixes two bugs related to rotation:
- rotation direction is wrong (reported by user ticket)
- rotation angle detection matches too broadly, including things like `\rangle=42` used in formulas (see #22)

INSPIR-3240