### PR TITLE
extractor: add support for \include to include secondary files

### DIFF
--- a/plotextractor/extractor.py
+++ b/plotextractor/extractor.py
@@ -199,6 +199,7 @@ def extract_captions(tex_file, sdir, image_list, primary=True):
     subfloat_head = u'\\subfloat'
     subfig_head = u'\\subfigure'
     includegraphics_head = u'\\includegraphics'
+    include_head = r'\\include(?!graphics)'  # matches only \include{}
     epsfig_head = u'\\epsfig'
     input_head = u'\\input'
     # possible caption lead-ins
@@ -366,6 +367,26 @@ def extract_captions(tex_file, sdir, image_list, primary=True):
         """
         index = line.find(input_head)
         if index > -1:
+            new_tex_names = intelligently_find_filenames(
+                line, TeX=True,
+                commas_okay=commas_okay)
+            for new_tex_name in new_tex_names:
+                if new_tex_name != 'ERROR':
+                    new_tex_file = get_tex_location(new_tex_name, tex_file)
+                    if new_tex_file and primary:  # to kill recursion
+                        extracted_image_data.extend(extract_captions(
+                            new_tex_file, sdir,
+                            image_list,
+                            primary=False
+                        ))
+
+        r"""
+        INCLUDE -
+        structure of include:
+        \include{FILENAME}
+        """
+        index = re.match(include_head, line)
+        if index:
             new_tex_names = intelligently_find_filenames(
                 line, TeX=True,
                 commas_okay=commas_okay)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -41,6 +41,14 @@ def tarball_flat():
 
 
 @pytest.fixture
+def tarball_test_for_include():
+    """Return path to testdata with include tags."""
+    return os.path.join(os.path.dirname(__file__),
+                        'data',
+                        '2207.tar.gz')
+
+
+@pytest.fixture
 def tarball_rotation():
     """Return path to testdata with an image file with rotation."""
     return os.path.join(os.path.dirname(__file__),
@@ -206,3 +214,14 @@ def test_process_tarball_with_utf_folder(tarball_utf):
         tarball_utf,
         output_directory=temporary_dir
     )
+
+
+def test_process_api_with_include(tarball_test_for_include):
+    """Test simple API for including the plots for \include tag."""
+    plots = plotextractor.process_tarball(tarball_test_for_include, context=True)
+    assert len(plots) == 155
+    assert "contexts" in plots[0]
+    assert "label" in plots[0]
+    assert "original_url" in plots[0]
+    assert "captions" in plots[0]
+    assert "name" in plots[0]


### PR DESCRIPTION
closes https://github.com/cern-sis/issues-inspire/issues/83